### PR TITLE
Add a high level API for editing checklist items.

### DIFF
--- a/trolly/board.py
+++ b/trolly/board.py
@@ -69,6 +69,19 @@ class Board( TrelloObject ):
         return self.createCard( card_json )
 
 
+    def getChecklists( self ):
+        """
+        Get the checklists for this board. Returns a list of Checklist objects.
+        """
+        checklists = self.getChecklistsJson( self.base_uri )
+
+        checklists_list = []
+        for checklist_json in checklists:
+            checklists_list.append( self.createChecklist( checklist_json ) )
+
+        return checklists_list
+
+
     def getMembers( self ):
         """
         Get Members attached to this board. Returns a list of Member objects.

--- a/trolly/checklist.py
+++ b/trolly/checklist.py
@@ -11,9 +11,10 @@ class Checklist( TrelloObject ):
     """
     Class representing a Trello Checklist
     """
-    def __init__( self, trello_client, checklist_id, name = '' ):
+    def __init__( self, trello_client, card_id, checklist_id, name = '' ):
         super( Checklist, self ).__init__( trello_client )
 
+        self.idCard = card_id
         self.id = checklist_id
         self.name = name
 
@@ -39,6 +40,17 @@ class Checklist( TrelloObject ):
                 uri_path = self.base_uri + '/checkItems',
                 query_params = query_params
             )
+
+
+    def getItemObjects( self, query_params = {} ):
+        """
+        Get the items for this checklist. Returns a list of ChecklistItem objects.
+        """
+        checklistitems_list = []
+        for checklistitem_json in self.getItems(query_params):
+            checklistitems_list.append( self.createChecklistItem( self.idCard, self.id, checklistitem_json ) )
+
+        return checklistitems_list
 
 
     def updateChecklist( self, name ):
@@ -73,3 +85,45 @@ class Checklist( TrelloObject ):
                 uri_path = self.base_uri + '/checkItems/' + item_id,
                 http_method = 'DELETE'
             )
+
+
+class ChecklistItem( TrelloObject ):
+    """
+    Class representing a Trello Checklist Item
+    """
+    def __init__( self, trello_client, card_id, checklist_id, checklistitem_id, name = '', state = 'incomplete'):
+        super( ChecklistItem, self ).__init__( trello_client )
+
+        self.idCard = card_id
+        self.idChecklist = checklist_id
+        self.id = checklistitem_id
+        self.name = name
+        self.state = (state == 'complete')
+
+        self.base_uri = '/cards/' + self.idCard + '/checklist/' + self.idChecklist + '/checkItem/' + self.id
+
+
+    def updateName( self, name ):
+        """
+        Rename the current checklist item. Returns a new ChecklistItem object.
+        """
+        checklistitem_json = self.fetchJson(
+                uri_path = self.base_uri + '/name',
+                http_method = 'PUT',
+                query_params = { 'value': name }
+            )
+
+        return self.createChecklistItem( self.idCard, self.idChecklist, checklistitem_json )
+
+
+    def updateState( self, state ):
+        """
+        Set the state of the current checklist item. Returns a new ChecklistItem object.
+        """
+        checklistitem_json = self.fetchJson(
+                uri_path = self.base_uri + '/state',
+                http_method = 'PUT',
+                query_params = { 'value': 'complete' if state else 'incomplete' }
+            )
+
+        return self.createChecklistItem( self.idCard, self.idChecklist, checklistitem_json )

--- a/trolly/client.py
+++ b/trolly/client.py
@@ -12,7 +12,7 @@ from organisation import Organisation
 from board import Board
 from list import List
 from card import Card
-from checklist import Checklist
+from checklist import Checklist, ChecklistItem
 from member import Member
 
 from trolly import Unauthorised, ResourceUnavailable
@@ -153,8 +153,23 @@ class Client( object ):
         """
         return Checklist( 
                 trello_client = self,
+                card_id = checklist_json['idCard'].encode('utf-8'),
                 checklist_id = checklist_json['id'].encode('utf-8'),
                 name = checklist_json['name'].encode( 'utf-8' )
+            )
+
+
+    def createChecklistItem( self, card_id, checklist_id, checklistitem_json ):
+        """
+        Create a ChecklistItem object from JSON object
+        """
+        return ChecklistItem(
+                trello_client = self,
+                card_id = card_id,
+                checklist_id = checklist_id,
+                checklistitem_id = checklistitem_json['id'].encode('utf-8'),
+                name = checklistitem_json['name'].encode( 'utf-8' ),
+                state = checklistitem_json['state'].encode( 'utf-8' )
             )
 
 

--- a/trolly/trelloobject.py
+++ b/trolly/trelloobject.py
@@ -83,5 +83,9 @@ class TrelloObject( object ):
         return self.client.createChecklist( checklist_json, **kwargs )
 
 
+    def createChecklistItem( self, card_id, checklist_id, checklistitem_json, **kwargs ):
+        return self.client.createChecklistItem( card_id, checklist_id, checklistitem_json, **kwargs )
+
+
     def createMember( self, member_json, **kwargs ):
         return self.client.createMember( member_json, **kwargs )


### PR DESCRIPTION
Hi,

For an integration I'm working on, I found the need to edit checklist item names and their state, but didn't find any nice way to do that via this wrapper. The API does have (slightly odd) methods for making this change, so I tried to wrap them up nicely.

## Commit message

Until now the only way to mark a checklist item as complete
was to remove it and re-add it which is certainly sub-optimal
and also messes with the ordering of items.

The exposed API does have a mechanism for updating the name
and state of checklist items but it's non-obvious and
requires that the both the card id and checklist id
are known.

This commit adds a highlevel API to do this renaming and
state changing.

In order to not break API, a new method called 'getItemObjects'
has been added to supplement the 'getItems' method of the
Checklist class. This new method will return objects rather
than a plain dict and exposes 'updateName' and 'updateState'
methods.