### PR TITLE
Fix JSON decoding under Python 3.x

### DIFF
--- a/trolly/client.py
+++ b/trolly/client.py
@@ -103,7 +103,7 @@ class Client( object ):
 
         self.checkErrors( uri, response )
 
-        return json.loads( str(content) )
+        return json.loads( content.decode() )
 
 
     def createOrganisation( self, organisation_json ):


### PR DESCRIPTION
str(b'{}') returns "b'{}'", which is invalid JSON.
As httplib2 under Python 2.x returns str already, we
can just use content.decode() unconditionally and it
should work with both Python 2.x and Python 3.x.
