### PR TITLE
Allow fetching of extra info such as comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Example usage of the client:
     for card in client.get_cards():
         print(' - %s' % card)
 
+    # Get all information from a card (works for boards, lists, etc. too):
+    print('Detailed cards:')
+    for card in client.get_cards(actions='all'):
+        print(' - %s: %s' % (card, card.data))
+
 
 ### Trello Object
 

--- a/trolly/__init__.py
+++ b/trolly/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     'Checklist',
     'Client',
     'List',
+    'Label',
     'Member',
     'Organisation',
     'ResourceUnavailable',

--- a/trolly/board.py
+++ b/trolly/board.py
@@ -24,14 +24,14 @@ class Board(trelloobject.TrelloObject):
             query_params=query_params or {}
         )
 
-    def get_lists(self):
+    def get_lists(self, **query_params):
         '''
         Get the lists attached to this board. Returns a list of List objects.
 
         Returns:
             list(List): The lists attached to this board
         '''
-        lists = self.get_lists_json(self.base_uri)
+        lists = self.get_lists_json(self.base_uri, query_params=query_params)
 
         lists_list = []
         for list_json in lists:
@@ -39,7 +39,7 @@ class Board(trelloobject.TrelloObject):
 
         return lists_list
 
-    def get_labels(self):
+    def get_labels(self, **query_params):
         '''
         Get the labels attached to this board. Returns a label of Label
         objects.
@@ -47,7 +47,7 @@ class Board(trelloobject.TrelloObject):
         Returns:
             list(Label): The labels attached to this board
         '''
-        labels = self.get_labels_json(self.base_uri)
+        labels = self.get_labels_json(self.base_uri, query_params=query_params)
 
         labels_list = []
         for label_json in labels:
@@ -55,14 +55,14 @@ class Board(trelloobject.TrelloObject):
 
         return labels_list
 
-    def get_cards(self):
+    def get_cards(self, **query_params):
         '''
         Get the cards for this board. Returns a list of Card objects.
 
         Returns:
             list(Card): The cards attached to this board
         '''
-        cards = self.get_cards_json(self.base_uri)
+        cards = self.get_cards_json(self.base_uri, query_params=query_params)
 
         cards_list = []
         for card_json in cards:
@@ -70,7 +70,7 @@ class Board(trelloobject.TrelloObject):
 
         return cards_list
 
-    def get_card(self, card_id):
+    def get_card(self, card_id, **query_params):
         '''
         Get a Card for a given card id. Returns a Card object.
 
@@ -83,14 +83,15 @@ class Board(trelloobject.TrelloObject):
 
         return self.create_card(card_json)
 
-    def get_members(self):
+    def get_members(self, **query_params):
         '''
         Get Members attached to this board. Returns a list of Member objects.
 
         Returns:
             list(Member): The members attached to this board
         '''
-        members = self.get_members_json(self.base_uri)
+        members = self.get_members_json(self.base_uri,
+                                        query_params=query_params)
 
         members_list = []
         for member_json in members:
@@ -98,14 +99,15 @@ class Board(trelloobject.TrelloObject):
 
         return members_list
 
-    def get_organisation(self):
+    def get_organisation(self, **query_params):
         '''
         Get the Organisation for this board. Returns Organisation object.
 
         Returns:
             list(Organisation): The organisation attached to this board
         '''
-        organisation_json = self.get_organisations_json(self.base_uri)
+        organisation_json = self.get_organisations_json(
+            self.base_uri, query_params=query_params)
 
         return self.create_organisation(organisation_json)
 

--- a/trolly/board.py
+++ b/trolly/board.py
@@ -7,8 +7,8 @@ class Board(trelloobject.TrelloObject):
     Class representing a Trello Board
     '''
 
-    def __init__(self, trello_client, board_id, name=''):
-        super(Board, self).__init__(trello_client)
+    def __init__(self, trello_client, board_id, name='', **kwargs):
+        super(Board, self).__init__(trello_client, **kwargs)
 
         self.id = board_id
         self.name = name

--- a/trolly/card.py
+++ b/trolly/card.py
@@ -9,9 +9,8 @@ class Card(trelloobject.TrelloObject):
     Class representing a Trello Card
     '''
 
-    def __init__(self, trello_client, card_id, name=''):
-
-        super(Card, self).__init__(trello_client)
+    def __init__(self, trello_client, card_id, name='', **kwargs):
+        super(Card, self).__init__(trello_client, **kwargs)
 
         self.id = card_id
         self.name = name

--- a/trolly/card.py
+++ b/trolly/card.py
@@ -27,34 +27,37 @@ class Card(trelloobject.TrelloObject):
             query_params=query_params or {}
         )
 
-    def get_board(self):
+    def get_board(self, **query_params):
         '''
         Get board information for this card. Returns a Board object.
 
         Returns:
             Board: The board this card is attached to
         '''
-        board_json = self.get_board_json(self.base_uri)
+        board_json = self.get_board_json(self.base_uri,
+                                         query_params=query_params)
         return self.create_board(board_json)
 
-    def get_list(self):
+    def get_list(self, **query_params):
         '''
         Get list information for this card. Returns a List object.
 
         Returns:
             List: The list this card is attached to
         '''
-        list_json = self.get_list_json(self.base_uri)
+        list_json = self.get_list_json(self.base_uri,
+                                       query_params=query_params)
         return self.create_list(list_json)
 
-    def get_checklists(self):
+    def get_checklists(self, **query_params):
         '''
         Get the checklists for this card. Returns a list of Checklist objects.
 
         Returns:
             list(Checklist): The checklists attached to this card
         '''
-        checklists = self.get_checklist_json(self.base_uri)
+        checklists = self.get_checklist_json(self.base_uri,
+                                             query_params=query_params)
 
         checklists_list = []
         for checklist_json in checklists:
@@ -62,7 +65,7 @@ class Card(trelloobject.TrelloObject):
 
         return checklists_list
 
-    def get_members(self):
+    def get_members(self, **query_params):
         '''
         Get all members attached to this card. Returns a list of Member
         objects.
@@ -70,7 +73,8 @@ class Card(trelloobject.TrelloObject):
         Returns:
             list(Member): The members attached to this card
         '''
-        members = self.get_members_json(self.base_uri)
+        members = self.get_members_json(self.base_uri,
+                                        query_params=query_params)
 
         members_list = []
         for member_json in members:

--- a/trolly/checklist.py
+++ b/trolly/checklist.py
@@ -7,8 +7,8 @@ class Checklist(trelloobject.TrelloObject):
     Class representing a Trello Checklist
     '''
 
-    def __init__(self, trello_client, checklist_id, name=''):
-        super(Checklist, self).__init__(trello_client)
+    def __init__(self, trello_client, checklist_id, name='', **kwargs):
+        super(Checklist, self).__init__(trello_client, **kwargs)
 
         self.id = checklist_id
         self.name = name

--- a/trolly/client.py
+++ b/trolly/client.py
@@ -105,7 +105,8 @@ class Client(object):
         return trolly.organisation.Organisation(
             trello_client=self,
             organisation_id=organisation_json['id'],
-            name=organisation_json['name']
+            name=organisation_json['name'],
+            data=organisation_json,
         )
 
     def create_board(self, board_json):
@@ -118,7 +119,8 @@ class Client(object):
         return trolly.board.Board(
             trello_client=self,
             board_id=board_json['id'],
-            name=board_json['name']
+            name=board_json['name'],
+            data=board_json,
         )
 
     def create_label(self, label_json):
@@ -131,7 +133,8 @@ class Client(object):
         return trolly.label.Label(
             trello_client=self,
             label_id=label_json['id'],
-            name=label_json['name']
+            name=label_json['name'],
+            data=label_json,
         )
 
     def create_list(self, list_json):
@@ -144,7 +147,8 @@ class Client(object):
         return trolly.list.List(
             trello_client=self,
             list_id=list_json['id'],
-            name=list_json['name']
+            name=list_json['name'],
+            data=list_json,
         )
 
     def create_card(self, card_json):
@@ -157,7 +161,8 @@ class Client(object):
         return trolly.card.Card(
             trello_client=self,
             card_id=card_json['id'],
-            name=card_json['name']
+            name=card_json['name'],
+            data=card_json,
         )
 
     def create_checklist(self, checklist_json):
@@ -170,7 +175,8 @@ class Client(object):
         return trolly.checklist.Checklist(
             trello_client=self,
             checklist_id=checklist_json['id'],
-            name=checklist_json['name']
+            name=checklist_json['name'],
+            data=checklist_json,
         )
 
     def create_member(self, member_json):
@@ -183,7 +189,8 @@ class Client(object):
         return trolly.member.Member(
             trello_client=self,
             member_id=member_json['id'],
-            name=member_json['fullName']
+            name=member_json['fullName'],
+            data=member_json,
         )
 
     def get_organisation(self, id, name=None):

--- a/trolly/client.py
+++ b/trolly/client.py
@@ -249,7 +249,7 @@ class Client(object):
         return self.create_member(dict(id=id, fullName=name))
 
     # Shortcut methods from the current member
-    def get_boards(self):
+    def get_boards(self, **query_params):
         '''
         Get all boards this member is attached to. Returns a list of Board
         objects.
@@ -257,9 +257,9 @@ class Client(object):
         Returns:
             list(Board): Return all boards for this member
         '''
-        return self.get_member().get_boards()
+        return self.get_member().get_boards(**query_params)
 
-    def get_cards(self):
+    def get_cards(self, **query_params):
         '''
         Get all cards this member is attached to. Return a list of Card
         objects.
@@ -267,9 +267,9 @@ class Client(object):
         Returns:
             list(Card): Return all cards this member is attached to
         '''
-        return self.get_member().get_cards()
+        return self.get_member().get_cards(**query_params)
 
-    def get_organisations(self):
+    def get_organisations(self, **query_params):
         '''
         Get all organisations this member is part of. Return a list of
         Organisation objects.
@@ -278,5 +278,5 @@ class Client(object):
             list(Organisation): Return all organisations this member is
             part of
         '''
-        return self.get_member().get_organisations()
+        return self.get_member().get_organisations(**query_params)
 

--- a/trolly/label.py
+++ b/trolly/label.py
@@ -7,8 +7,8 @@ class Label(trelloobject.TrelloObject):
     Class representing a Trello Label
     '''
 
-    def __init__(self, trello_client, label_id, name=''):
-        super(Label, self).__init__(trello_client)
+    def __init__(self, trello_client, label_id, name='', **kwargs):
+        super(Label, self).__init__(trello_client, **kwargs)
 
         self.id = label_id
         self.name = name

--- a/trolly/list.py
+++ b/trolly/list.py
@@ -7,8 +7,8 @@ class List(trelloobject.TrelloObject):
     Class representing a Trello List
     '''
 
-    def __init__(self, trello_client, list_id, name=''):
-        super(List, self).__init__(trello_client)
+    def __init__(self, trello_client, list_id, name='', **kwargs):
+        super(List, self).__init__(trello_client, **kwargs)
 
         self.id = list_id
         self.name = name

--- a/trolly/member.py
+++ b/trolly/member.py
@@ -26,7 +26,7 @@ class Member(trelloobject.TrelloObject):
             query_params=query_params or {}
         )
 
-    def get_boards(self):
+    def get_boards(self, **query_params):
         '''
         Get all boards this member is attached to. Returns a list of Board
         objects.
@@ -34,7 +34,7 @@ class Member(trelloobject.TrelloObject):
         Returns:
             list(Board): Return all boards for this member
         '''
-        boards = self.get_boards_json(self.base_uri)
+        boards = self.get_boards_json(self.base_uri, query_params=query_params)
 
         boards_list = []
         for board_json in boards:
@@ -42,7 +42,7 @@ class Member(trelloobject.TrelloObject):
 
         return boards_list
 
-    def get_cards(self):
+    def get_cards(self, **query_params):
         '''
         Get all cards this member is attached to. Return a list of Card
         objects.
@@ -50,7 +50,7 @@ class Member(trelloobject.TrelloObject):
         Returns:
             list(Card): Return all cards this member is attached to
         '''
-        cards = self.get_cards_json(self.base_uri)
+        cards = self.get_cards_json(self.base_uri, query_params=query_params)
 
         cards_list = []
         for card_json in cards:
@@ -58,7 +58,7 @@ class Member(trelloobject.TrelloObject):
 
         return cards_list
 
-    def get_organisations(self):
+    def get_organisations(self, **query_params):
         '''
         Get all organisations this member is attached to. Return a list of
         Organisation objects.
@@ -67,7 +67,8 @@ class Member(trelloobject.TrelloObject):
             list(Organisation): Return all organisations this member is
             attached to
         '''
-        organisations = self.get_organisations_json(self.base_uri)
+        organisations = self.get_organisations_json(self.base_uri,
+                                                    query_params=query_params)
 
         organisations_list = []
         for organisation_json in organisations:

--- a/trolly/member.py
+++ b/trolly/member.py
@@ -7,9 +7,8 @@ class Member(trelloobject.TrelloObject):
     Class representing a Trello Member
     '''
 
-    def __init__(self, trello_client, member_id, name=''):
-
-        super(Member, self).__init__(trello_client)
+    def __init__(self, trello_client, member_id, name='', **kwargs):
+        super(Member, self).__init__(trello_client, **kwargs)
         self.id = member_id
         self.name = name
 

--- a/trolly/organisation.py
+++ b/trolly/organisation.py
@@ -20,14 +20,14 @@ class Organisation(trelloobject.TrelloObject):
             query_params=query_params or {}
         )
 
-    def get_boards(self):
+    def get_boards(self, **query_params):
         '''
         Get all the boards for this organisation. Returns a list of Board s.
 
         Returns:
             list(Board): The boards attached to this organisation
         '''
-        boards = self.get_boards_json(self.base_uri)
+        boards = self.get_boards_json(self.base_uri, query_params=query_params)
 
         boards_list = []
         for board_json in boards:
@@ -35,7 +35,7 @@ class Organisation(trelloobject.TrelloObject):
 
         return boards_list
 
-    def get_members(self):
+    def get_members(self, **query_params):
         '''
         Get all members attached to this organisation. Returns a list of
         Member objects
@@ -43,7 +43,8 @@ class Organisation(trelloobject.TrelloObject):
         Returns:
             list(Member): The members attached to this organisation
         '''
-        members = self.get_members_json(self.base_uri)
+        members = self.get_members_json(self.base_uri,
+                                        query_params=query_params)
 
         members_list = []
         for member_json in members:

--- a/trolly/organisation.py
+++ b/trolly/organisation.py
@@ -3,8 +3,8 @@ from . import trelloobject
 
 class Organisation(trelloobject.TrelloObject):
 
-    def __init__(self, trello_client, organisation_id, name=''):
-        super(Organisation, self).__init__(trello_client)
+    def __init__(self, trello_client, organisation_id, name='', **kwargs):
+        super(Organisation, self).__init__(trello_client, **kwargs)
 
         self.id = organisation_id
         self.name = name

--- a/trolly/trelloobject.py
+++ b/trolly/trelloobject.py
@@ -8,13 +8,20 @@ class TrelloObject(object):
     objects and masks the client calls as methods belonging to the object.
     '''
 
-    def __init__(self, trello_client):
+    def __init__(self, trello_client, **kwargs):
         '''
         A Trello client, Oauth of HTTP client is required for each object.
         '''
         super(TrelloObject, self).__init__()
 
         self.client = trello_client
+        self.data = kwargs.get('data', {})
+
+    def __getattr__(self, key):
+        if key != 'data' and key in self.data:
+            return self.data[key]
+        else:
+            raise AttributeError('Unknown attribute %s' % key)
 
     def __repr__(self):
         return '<%s[%s] %s>' % (

--- a/trolly/trelloobject.py
+++ b/trolly/trelloobject.py
@@ -33,32 +33,38 @@ class TrelloObject(object):
             headers=headers or {}
         )
 
-    def get_organisations_json(self, base_uri):
-        return self.fetch_json(base_uri + '/organizations')
+    def get_comments(self, query_params=None):
+        return self.fetch_json(self.base_uri, query_params=query_params)
 
-    def get_boards_json(self, base_uri):
-        return self.fetch_json(base_uri + '/boards')
+    def get_organisations_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/organizations',
+                               query_params=query_params)
 
-    def get_labels_json(self, base_uri):
-        return self.fetch_json(base_uri + '/labels')
+    def get_boards_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/boards', query_params=query_params)
 
-    def get_board_json(self, base_uri):
-        return self.fetch_json(base_uri + '/board')
+    def get_labels_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/labels', query_params=query_params)
 
-    def get_lists_json(self, base_uri):
-        return self.fetch_json(base_uri + '/lists')
+    def get_board_json(self, base_uri, actions='all', query_params=None):
+        return self.fetch_json(base_uri + '/board', query_params=query_params)
 
-    def get_list_json(self, base_uri):
-        return self.fetch_json(base_uri + '/list')
+    def get_lists_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/lists', query_params=query_params)
 
-    def get_cards_json(self, base_uri):
-        return self.fetch_json(base_uri + '/cards')
+    def get_list_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/list', query_params=query_params)
 
-    def get_checklist_json(self, base_uri):
-        return self.fetch_json(base_uri + '/checklists')
+    def get_cards_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/cards', query_params=query_params)
 
-    def get_members_json(self, base_uri):
-        return self.fetch_json(base_uri + '/members')
+    def get_checklist_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/checklists',
+                               query_params=query_params)
+
+    def get_members_json(self, base_uri, query_params=None):
+        return self.fetch_json(base_uri + '/members',
+                               query_params=query_params)
 
     def create_organisation(self, organisation_json, **kwargs):
         '''


### PR DESCRIPTION
The Trello API can return quite a bit more data but the previous api didn't easily support that. Now all get functions have optional `query_params` which allow for parameters such as actions to fetch comments and such.